### PR TITLE
Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
     - "2.7"
     - "3.3"
+    - "3.4"
+    - "3.5"
 # command to install dependencies
 install:
     - "pip install -r requirements.txt"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from setuptools import setup
 from semverpy import __version__, __author__, __license__
 
+
+classifiers = [
+    'Programming Language :: Python :: {}'.format(v)
+    for v in (2, 2.7, 3, 3.3, 3.4, 3.5,)]
+
+
 setup(
     name='SemVerPy',
     description='Bump versions. Semantically.',
@@ -9,5 +15,6 @@ setup(
     author_email='k@mackwerk.dk',
     license=__license__,
     url='https://github.com/Dinoshauer/SemVerPy',
-    py_modules=['semverpy']
+    py_modules=['semverpy'],
+    classifiers=classifiers
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33
+envlist = py27,py33,py34,py35
 [testenv]
 deps = nose
 commands = nosetests


### PR DESCRIPTION
- Added Python 3.4 and 3.5 to the list of environments used by Tox and Travis.
- Set the `Programming Language :: Python :: _` classifiers in `setup.py` so tools like https://github.com/brettcannon/caniusepython3  can determine this package supports Python 3.